### PR TITLE
Fixed integer overflow when hashing large files, causing invalid hashes

### DIFF
--- a/files.c
+++ b/files.c
@@ -182,7 +182,7 @@ int HashratHashFile(HashratCtx *Ctx, THash *Hash, int Type, char *Path, off_t Fi
 STREAM *S;
 char *Tempstr=NULL, *User=NULL, *Pass=NULL;
 int result, val, RetVal=FALSE;
-off_t bytes_read=0;
+off_t bytes_read=0, oval;
 
 switch (Type)
 {
@@ -210,8 +210,9 @@ if (S)
 {
 Tempstr=SetStrLen(Tempstr,BUFSIZ);
 
-val=FileSize;
-if ((val==0) || ( val > BUFSIZ)) val=BUFSIZ;
+oval=FileSize;
+if ((oval==0) || ( oval > BUFSIZ)) val=BUFSIZ;
+else val=(int)oval;
 result=STREAMReadBytes(S,Tempstr,val);
 while (result > 0)
 {
@@ -223,8 +224,9 @@ while (result > 0)
 	if (FileSize > 0)
 	{
 	if ((Type != FT_HTTP) && (bytes_read >= FileSize)) break;
-	val=FileSize - bytes_read;
-	if (val > BUFSIZ) val=BUFSIZ;
+	oval=FileSize - bytes_read;
+	if (oval > BUFSIZ) val=BUFSIZ;
+	else val=(int)oval;
 	}
 	result=STREAMReadBytes(S,Tempstr,val);
 }
@@ -267,7 +269,7 @@ int HashratHashSingleFile(HashratCtx *Ctx, char *HashType, int FileType, char *P
 THash *Hash;
 struct stat XattrStat;
 char *ptr;
-int size=0;
+off_t size=0;
 
 		*RetStr=CopyStr(*RetStr,"");
 


### PR DESCRIPTION
Large files >2GB didn't get hashed correctly on my system (Ubuntu xenial, amd64). The reason was a conversion from `off_t` to `int` that resulted in negative or otherwise invalid size values, so that only a part of the file got hashed.

To reproduce the problem, create a file slightly larger than 2GB and hash it:
```
$ dd if=/dev/zero bs=1024 count=2097153 of=./largefile
[...]
$ hashrat largefile
hash='md5:d41d8cd98f00b204e9800998ecf8427e' type='file' mode='100664' uid='1000' gid='1000' size='2147484672' mtime='1506032124' inode='1615087' path='largefile'
```

Appending to the file should change its hash, but doesn't:
```
$ echo "some changes" >> largefile
$ hashrat largefile   # the file is now larger, but still shows the same hash
hash='md5:d41d8cd98f00b204e9800998ecf8427e' type='file' mode='100664' uid='1000' gid='1000' size='2147484685' mtime='1506032178' inode='1615087' path='largefile'
```

This pull request fixes the problem.