### PR TITLE
Defines SHA2_UNROLL_TRANSFORM for faster SHA2 hashing

### DIFF
--- a/libUseful-2.5/Makefile
+++ b/libUseful-2.5/Makefile
@@ -113,7 +113,7 @@ sha1.o: sha1.c sha1.h
 	$(CC) $(FLAGS) -c sha1.c
 
 sha2.o: sha2.c sha2.h
-	$(CC) $(FLAGS) -c sha2.c
+	$(CC) $(FLAGS) -DSHA2_UNROLL_TRANSFORM -c sha2.c
 
 whirlpool.o: whirlpool.c whirlpool.h
 	$(CC) $(FLAGS) -c whirlpool.c

--- a/libUseful-2.5/Makefile.in
+++ b/libUseful-2.5/Makefile.in
@@ -113,7 +113,7 @@ sha1.o: sha1.c sha1.h
 	$(CC) $(FLAGS) -c sha1.c
 
 sha2.o: sha2.c sha2.h
-	$(CC) $(FLAGS) -c sha2.c
+	$(CC) $(FLAGS) -DSHA2_UNROLL_TRANSFORM -c sha2.c
 
 whirlpool.o: whirlpool.c whirlpool.h
 	$(CC) $(FLAGS) -c whirlpool.c


### PR DESCRIPTION
Fixes: #10 

Adds -DSHA2_UNROLL_TRANSFORM as a flag in the Makefile when compiling sha2.c