### PR TITLE
Fix build without OpenSSL

### DIFF
--- a/libUseful-5/StreamAuth.c
+++ b/libUseful-5/StreamAuth.c
@@ -105,12 +105,13 @@ static int STREAMAuthProcess(STREAM *S, const char *AuthTypes)
 
 int STREAMAuth(STREAM *S)
 {
+#ifdef HAVE_LIBSSL
     const char *ptr;
 
     ptr=STREAMGetValue(S, "Authenticator");
     if (! StrValid(ptr)) return(TRUE);
 
     return(STREAMAuthProcess(S, ptr));
-
+#endif
     return(FALSE);
 }


### PR DESCRIPTION
Fixes the following error for builds without libssl:

```
/usr/bin/ld: libUseful-5/libUseful.a(StreamAuth.o): in function `STREAMAuthProcessCertificate':
./libUseful-5/./libUseful-5/StreamAuth.c:22:(.text+0x18): undefined reference to `OpenSSLCertDetailsGetCommonName'
collect2: error: ld returned 1 exit status
```