### PR TITLE
Fix manpage font formatting

### DIFF
--- a/hashrat.1
+++ b/hashrat.1
@@ -107,23 +107,23 @@ Encode with decimal instead of hex.
 Encode with UPPERCASE hexadecimal.
 .TP
 .B
-\fb-32\fp, \fb-base32\fp
+\fB-32\fP, \fB-base32\fP
 encode with base32. 
 .TP
 .B
-\fb-c32\fp
+\fB-c32\fP
 encode with Crockfords base32. 
 .TP
 .B
-\fb-w32\fp
+\fB-w32\fP
 encode with word-safe base32. 
 .TP
 .B
-\fb-z32\fp
+\fB-z32\fP
 encode with zbase32. 
 .TP
 .B
-\fb-64\fp, \fb-base64\fp
+\fB-64\fP, \fB-base64\fP
 encode with base64. 
 .TP
 .B


### PR DESCRIPTION
Hi,

When building the project in Debian, I encountered a warning from lintian regarding the manpage:

`W: hashrat: groff-message troff:<standard input>:110: warning: cannot select font 'b' [usr/share/man/man1/hashrat.1.gz:1]`

This issue is caused by the use of lowercase font commands \fb and \fp in the manpage, which should be replaced with uppercase \fB and \fP.

You can find more information about this warning here:
https://lintian.debian.org/tags/groff-message